### PR TITLE
Remove corrupted image

### DIFF
--- a/_data/table.csv
+++ b/_data/table.csv
@@ -27,7 +27,6 @@ OME-NGFF version,EMBL-EBI bucket (current),SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,We
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001256.zarr,350,372,61,4,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001257.zarr,3763,2860,145,4,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001258.zarr,1282,838,36,3,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9798462.zarr,21115,16433,1,3,1,XYZCT,,,CC BY 4.0,idr0073,,2020-11-04
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9822151.zarr,79360,167424,1,1,1,XYZCT,,,CC BY 4.0,idr0083,https://doi.org/10.5281/zenodo.5546093,2020-11-04
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9822152.zarr,144384,93184,1,1,1,XYZCT,,,CC BY 4.0,idr0083,,2020-11-04
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836831.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04


### PR DESCRIPTION
Removes https://hms-dbmi.github.io/vizarr/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9798462.zarr from table.
cc @sbesson 