### PR TITLE
Add copy-to-clipboard button for s3 urls

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,7 +57,7 @@ title: "Catalog of IDR images formatted as OME-NGFF"
                 <a href="{{ rec[s3key] }}">
                     {{ image_name }}
                 </a>
-                <button title="Copy to clipboard" onclick="copyTextToClipboard('{{ rec[s3key] }}'">Copy</button>
+                <button style="display:block" title="Copy to clipboard" onclick="copyTextToClipboard('{{ rec[s3key] }}')">Copy</button>
             </td>
             <td>{{ rec.["SizeX"] }}</td>
             <td>{{ rec.["SizeY"] }}</td>

--- a/index.md
+++ b/index.md
@@ -57,6 +57,7 @@ title: "Catalog of IDR images formatted as OME-NGFF"
                 <a href="{{ rec[s3key] }}">
                     {{ image_name }}
                 </a>
+                <button title="Copy to clipboard" onclick="copyTextToClipboard('{{ rec[s3key] }}'">Copy</button>
             </td>
             <td>{{ rec.["SizeX"] }}</td>
             <td>{{ rec.["SizeY"] }}</td>
@@ -86,4 +87,38 @@ $(document).ready( function () {
           "pageLength": 100
     });
 } );
+
+
+function copyTextToClipboard(text) {
+    var textArea = document.createElement("textarea");
+    // Place in the top-left corner of screen regardless of scroll position.
+    textArea.style.position = 'fixed';
+
+    textArea.value = text;
+
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    var successful;
+    try {
+        successful = document.execCommand('copy');
+    } catch (err) {
+        console.log('Oops, unable to copy');
+    }
+    document.body.removeChild(textArea);
+
+    if (successful) {
+        // show user that copying happened - update text on element (e.g. button)
+        let target = event.target;
+        let html = target.innerHTML;
+        target.innerHTML = "Copied!"
+        setTimeout(() => {
+            // reset after 1 second
+            target.innerHTML = html
+        }, 1000)
+    } else {
+        console.log("Copying failed")
+    }
+}
 </script>


### PR DESCRIPTION
Applying changes from https://github.com/ome/www.openmicroscopy.org/pull/564/ to here to add a copy button.

But, I haven't managed to test locally due to not having Jekyll installed.

https://utpalkumar.medium.com/how-to-install-jekyll-on-apple-m1-macbook-c87894b7fc70 looks painful.

So I tried https://anaconda.org/conda-forge/rb-jekyll ...

```
conda create --name jekyll
conda activate jekyll
conda install -c conda-forge rb-jekyll
cd Desktop/IDR/ome-ngff-samples/
jekyll Gemfile     # failed
gem install kramdown
jekyll Gemfile
"The git source git://github.com/jekyll/minima.git is not yet checked out. Please run `bundle install` before trying to start your application (Bundler::GitError)"

bundle install
Git error: command `git clone 'git://github.com/jekyll/minima.git'
"/Users/wmoore/opt/anaconda3/envs/jekyll/lib/ruby/gems/2.6.0/cache/bundler/git/minima-fb70e785e8f77ebad3d6dcf03ba0925ecdb47b21" --bare --no-hardlinks --quiet` in directory
/Users/wmoore/Desktop/IDR/ome-ngff-samples has failed.
```