### PR TITLE
Link image in idr

### DIFF
--- a/_data/table.csv
+++ b/_data/table.csv
@@ -1,74 +1,74 @@
-OME-NGFF version,EMBL-EBI bucket (current),SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,Wells,Fields,Keywords,License,Study,DOI,Date added,Thumb ID
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/12689244.zarr,4992,4255,401,3,1,XYZCT,,,,CC BY 4.0,idr0106,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/179706.zarr,1344,1024,1,2,329,XYZCT,,,,CC BY 4.0,idr0002,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/1884807.zarr,256,256,1,3,1,XYZCT,,,,CC BY 4.0,idr0021,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/1885619.zarr,30,30,571,1,1,XYZCT,,,,CC BY 4.0,idr0023,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/4007801.zarr,2169,2048,988,2,532,XYZCT,,,,CC BY 4.0,idr0044,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/4495402.zarr,921600,380928,1,1,1,XYZCT,,,,CC BY-NC-SA 3.0,idr0053,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001237.zarr,1024,1024,39,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001238.zarr,1024,1024,27,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001239.zarr,1024,1024,36,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr,271,275,236,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001241.zarr,278,263,236,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001242.zarr,481,275,237,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001243.zarr,212,218,237,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001244.zarr,325,281,239,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001245.zarr,220,226,257,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001246.zarr,281,284,257,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001247.zarr,253,210,257,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001248.zarr,234,269,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001249.zarr,246,241,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001250.zarr,246,241,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001251.zarr,170,163,140,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001252.zarr,170,163,297,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001253.zarr,803,1024,297,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001254.zarr,393,354,51,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001255.zarr,551,416,32,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001256.zarr,350,372,61,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001257.zarr,3763,2860,145,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001258.zarr,1282,838,36,3,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9822151.zarr,79360,167424,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,https://doi.org/10.5281/zenodo.5546093,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9822152.zarr,144384,93184,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836831.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836832.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836833.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836834.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836835.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836836.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836837.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836838.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836839.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836840.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836841.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836842.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836843.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836844.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836845.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836846.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836950.zarr,1636,816,156,1,1,XYZCT,,,,CC BY 4.0,idr0079,,2020-11-04,
+OME-NGFF version,EMBL-EBI bucket (current),SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,Wells,Fields,Keywords,License,Study,DOI,Date added,Representative Image ID
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/12689244.zarr,4992,4255,401,3,1,XYZCT,,,,CC BY 4.0,idr0106,,2020-11-04,12689244
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/179706.zarr,1344,1024,1,2,329,XYZCT,,,,CC BY 4.0,idr0002,,2020-11-04,179706
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/1884807.zarr,256,256,1,3,1,XYZCT,,,,CC BY 4.0,idr0021,,2020-11-04,1884807
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/1885619.zarr,30,30,571,1,1,XYZCT,,,,CC BY 4.0,idr0023,,2020-11-04,1885619
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/4007801.zarr,2169,2048,988,2,532,XYZCT,,,,CC BY 4.0,idr0044,,2020-11-04,4007801
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/4495402.zarr,921600,380928,1,1,1,XYZCT,,,,CC BY-NC-SA 3.0,idr0053,,2020-11-04,4495402
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001237.zarr,1024,1024,39,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001237
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001238.zarr,1024,1024,27,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001238
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001239.zarr,1024,1024,36,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001239
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr,271,275,236,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-11-04,6001240
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001241.zarr,278,263,236,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001241
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001242.zarr,481,275,237,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001242
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001243.zarr,212,218,237,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001243
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001244.zarr,325,281,239,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001244
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001245.zarr,220,226,257,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001245
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001246.zarr,281,284,257,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001246
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001247.zarr,253,210,257,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-11-04,6001247
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001248.zarr,234,269,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001248
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001249.zarr,246,241,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001249
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001250.zarr,246,241,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001250
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001251.zarr,170,163,140,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001251
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001252.zarr,170,163,297,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001252
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001253.zarr,803,1024,297,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001253
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001254.zarr,393,354,51,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001254
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001255.zarr,551,416,32,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001255
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001256.zarr,350,372,61,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001256
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001257.zarr,3763,2860,145,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001257
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001258.zarr,1282,838,36,3,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001258
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9822151.zarr,79360,167424,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,https://doi.org/10.5281/zenodo.5546093,2020-11-04,9822151
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9822152.zarr,144384,93184,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,,2020-11-04,9822152
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836831.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836831
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836832.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836832
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836833.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836833
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836834.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836834
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836835.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836835
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836836.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836836
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836837.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836837
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836838.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836838
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836839.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836839
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836840.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836840
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836841.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836841
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836842.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836842
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836843.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836843
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836844.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836844
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836845.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836845
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836846.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836846
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836950.zarr,1636,816,156,1,1,XYZCT,,,,CC BY 4.0,idr0079,,2020-11-04,9836950
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/1751.zarr,672,510,10,2,1,XYZCT,69,1,,CC BY-NC-SA 3.0,idr0004,https://doi.org/10.5281/zenodo.5741293,2020-12-01,692166
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/2551.zarr,1376,1040,16,2,1,XYZCT,96,6,,CC BY 4.0,idr0001,https://zenodo.org/record/5735098,2020-12-01,1230059
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/422.zarr,1344,1024,1,2,329,XYZCT,96,1,,CC BY 4.0,idr0002,,2020-12-01,179693
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/5966.zarr,1080,1080,1,5,1,XYZCT,384,9,,CC BY 4.0,idr0033,https://zenodo.org/record/5742744,2020-12-01,3231627
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/7825.zarr,1080,1080,1,1,1,XYZCT,96,9,,CC0 1.0,idr0094,https://zenodo.org/record/5745520,2020-12-01,10568780
-0.2,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001240.zarr,271,275,236,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2021-03-09,
-0.2,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001247.zarr,253,210,257,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-12-01,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr,1920,1920,,4,,XYC,,,,CC BY 4.0,idr0077,,2021-12-16,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0079A/9836998.zarr,1584,788,142,2,,XYZC ,,,labels (0),CC BY 4.0,idr0079,,2021-12-16,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0052A/5514375.zarr,256,256,31,3,40,XYZCT,,,"labels (cells, chromosomes)",CC BY 4.0,idr0052,,2021-12-16,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511419.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511420.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511421.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511422.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511423.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511424.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
+0.2,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001240.zarr,271,275,236,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2021-03-09,6001240
+0.2,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001247.zarr,253,210,257,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-12-01,6001247
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr,1920,1920,,4,,XYC,,,,CC BY 4.0,idr0077,,2021-12-16,9836842
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0079A/9836998.zarr,1584,788,142,2,,XYZC ,,,labels (0),CC BY 4.0,idr0079,,2021-12-16,9836998
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0052A/5514375.zarr,256,256,31,3,40,XYZCT,,,"labels (cells, chromosomes)",CC BY 4.0,idr0052,,2021-12-16,5514375
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511419.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511419
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511420.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511420
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511421.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511421
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511422.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511422
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511423.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511423
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511424.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511424
 0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0094A/7751.zarr,1080,1080,,,,XY,96,9,labels,CC0 1.0,idr0094,,2021-12-16,10503791
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0109A/12922361.zarr,2560,2160,,,721,XYT,,,,CC BY 4.0,idr0109,,2021-12-16,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0075A/9528933.zarr,512,512,91,,,XYZ,,,,CC BY 4.0,idr0075,,2021-12-16,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0051A/4007817.zarr,333,333,201,,79,XYZT,,,,CC BY 4.0,idr0051,,2021-12-16,
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0040A/3491626.zarr,2048,2048,,5,20,XYCT,,,,CC BY 4.0,idr0040,,2021-12-16,
-0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr/,21115,16433,1,3,1,XYZCT,,,,CC BY 4.0,idr0073,,2022-05-05,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0109A/12922361.zarr,2560,2160,,,721,XYT,,,,CC BY 4.0,idr0109,,2021-12-16,12922361
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0075A/9528933.zarr,512,512,91,,,XYZ,,,,CC BY 4.0,idr0075,,2021-12-16,9528933
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0051A/4007817.zarr,333,333,201,,79,XYZT,,,,CC BY 4.0,idr0051,,2021-12-16,4007817
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0040A/3491626.zarr,2048,2048,,5,20,XYCT,,,,CC BY 4.0,idr0040,,2021-12-16,3491626
+0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr/,21115,16433,1,3,1,XYZCT,,,,CC BY 4.0,idr0073,,2022-05-05,9798462
 0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0072B/9512.zarr,1345,1017,1,2,1,XYC,72,20,,CC BY 4.0,idr0072,,2022-05-10,12867352
-0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0083A/9822152.zarr,144384,93184,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,,2022-05-11,
-0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001247.zarr,253,210,257,2,,XYZC,,,labels (0),CC BY 4.0,idr0062,,2022-05-11,
-0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0044A/4007801.zarr,2169,2048,988,2,532,XYZCT,,,,CC BY 4.0,idr0044,,2022-05-17,
+0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0083A/9822152.zarr,144384,93184,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,,2022-05-11,9822152
+0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001247.zarr,253,210,257,2,,XYZC,,,labels (0),CC BY 4.0,idr0062,,2022-05-11,6001247
+0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0044A/4007801.zarr,2169,2048,988,2,532,XYZCT,,,,CC BY 4.0,idr0044,,2022-05-17,4007801

--- a/_data/table.csv
+++ b/_data/table.csv
@@ -1,74 +1,74 @@
-OME-NGFF version,EMBL-EBI bucket (current),SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,Wells,Keywords,License,Study,DOI,Date added
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/12689244.zarr,4992,4255,401,3,1,XYZCT,,,CC BY 4.0,idr0106,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/179706.zarr,1344,1024,1,2,329,XYZCT,,,CC BY 4.0,idr0002,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/1884807.zarr,256,256,1,3,1,XYZCT,,,CC BY 4.0,idr0021,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/1885619.zarr,30,30,571,1,1,XYZCT,,,CC BY 4.0,idr0023,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/4007801.zarr,2169,2048,988,2,532,XYZCT,,,CC BY 4.0,idr0044,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/4495402.zarr,921600,380928,1,1,1,XYZCT,,,CC BY-NC-SA 3.0,idr0053,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001237.zarr,1024,1024,39,4,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001238.zarr,1024,1024,27,4,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001239.zarr,1024,1024,36,4,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr,271,275,236,2,1,XYZCT,,labels (0),CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001241.zarr,278,263,236,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001242.zarr,481,275,237,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001243.zarr,212,218,237,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001244.zarr,325,281,239,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001245.zarr,220,226,257,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001246.zarr,281,284,257,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001247.zarr,253,210,257,2,1,XYZCT,,labels (0),CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001248.zarr,234,269,195,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001249.zarr,246,241,195,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001250.zarr,246,241,195,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001251.zarr,170,163,140,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001252.zarr,170,163,297,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001253.zarr,803,1024,297,2,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001254.zarr,393,354,51,4,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001255.zarr,551,416,32,4,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001256.zarr,350,372,61,4,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001257.zarr,3763,2860,145,4,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001258.zarr,1282,838,36,3,1,XYZCT,,,CC BY 4.0,idr0062,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9822151.zarr,79360,167424,1,1,1,XYZCT,,,CC BY 4.0,idr0083,https://doi.org/10.5281/zenodo.5546093,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9822152.zarr,144384,93184,1,1,1,XYZCT,,,CC BY 4.0,idr0083,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836831.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836832.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836833.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836834.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836835.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836836.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836837.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836838.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836839.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836840.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836841.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836842.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836843.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836844.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836845.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836846.zarr,1920,1920,259,4,1,XYZCT,,,CC BY 4.0,idr0077,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836950.zarr,1636,816,156,1,1,XYZCT,,,CC BY 4.0,idr0079,,2020-11-04
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/1751.zarr,672,510,10,2,1,XYZCT,69,,CC BY-NC-SA 3.0,idr0004,https://doi.org/10.5281/zenodo.5741293,2020-12-01
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/2551.zarr,1376,1040,16,2,1,XYZCT,96,,CC BY 4.0,idr0001,https://zenodo.org/record/5735098,2020-12-01
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/422.zarr,1344,1024,1,2,329,XYZCT,96,,CC BY 4.0,idr0002,,2020-12-01
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/5966.zarr,1080,1080,1,5,1,XYZCT,384,,CC BY 4.0,idr0033,https://zenodo.org/record/5742744,2020-12-01
-0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/7825.zarr,1080,1080,1,1,1,XYZCT,96,,CC0 1.0,idr0094,https://zenodo.org/record/5745520,2020-12-01
-0.2,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001240.zarr,271,275,236,2,1,XYZCT,,labels (0),CC BY 4.0,idr0062,,2021-03-09
-0.2,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001247.zarr,253,210,257,2,1,XYZCT,,labels (0),CC BY 4.0,idr0062,,2020-12-01
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr,1920,1920,,4,,XYC,,,CC BY 4.0,idr0077,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0079A/9836998.zarr,1584,788,142,2,,XYZC ,,labels (0),CC BY 4.0,idr0079,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0052A/5514375.zarr,256,256,31,3,40,XYZCT,,"labels (cells, chromosomes)",CC BY 4.0,idr0052,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511419.zarr,2048,2048,,3,,XYC,,labels (0),CC BY 4.0,idr0095,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511420.zarr,2048,2048,,3,,XYC,,labels (0),CC BY 4.0,idr0095,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511421.zarr,2048,2048,,3,,XYC,,labels (0),CC BY 4.0,idr0095,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511422.zarr,2048,2048,,3,,XYC,,labels (0),CC BY 4.0,idr0095,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511423.zarr,2048,2048,,3,,XYC,,labels (0),CC BY 4.0,idr0095,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511424.zarr,2048,2048,,3,,XYC,,labels (0),CC BY 4.0,idr0095,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0094A/7751.zarr,1080,1080,,,,XY,96,labels,CC0 1.0,idr0094,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0109A/12922361.zarr,2560,2160,,,721,XYT,,,CC BY 4.0,idr0109,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0075A/9528933.zarr,512,512,91,,,XYZ,,,CC BY 4.0,idr0075,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0051A/4007817.zarr,333,333,201,,79,XYZT,,,CC BY 4.0,idr0051,,2021-12-16
-0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0040A/3491626.zarr,2048,2048,,5,20,XYCT,,,CC BY 4.0,idr0040,,2021-12-16
-0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr/,21115,16433,1,3,1,XYZCT,,,CC BY 4.0,idr0073,,2022-05-05
-0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0072B/9512.zarr,1345,1017,1,2,1,XYC,72,,CC BY 4.0,idr0072,,2022-05-10
-0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0083A/9822152.zarr,144384,93184,1,1,1,XYZCT,,,CC BY 4.0,idr0083,,2022-05-11
-0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001247.zarr,253,210,257,2,,XYZC,,labels (0),CC BY 4.0,idr0062,,2022-05-11
-0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0044A/4007801.zarr,2169,2048,988,2,532,XYZCT,,,CC BY 4.0,idr0044,,2022-05-17
+OME-NGFF version,EMBL-EBI bucket (current),SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,Wells,Fields,Keywords,License,Study,DOI,Date added,Thumb ID
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/12689244.zarr,4992,4255,401,3,1,XYZCT,,,,CC BY 4.0,idr0106,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/179706.zarr,1344,1024,1,2,329,XYZCT,,,,CC BY 4.0,idr0002,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/1884807.zarr,256,256,1,3,1,XYZCT,,,,CC BY 4.0,idr0021,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/1885619.zarr,30,30,571,1,1,XYZCT,,,,CC BY 4.0,idr0023,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/4007801.zarr,2169,2048,988,2,532,XYZCT,,,,CC BY 4.0,idr0044,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/4495402.zarr,921600,380928,1,1,1,XYZCT,,,,CC BY-NC-SA 3.0,idr0053,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001237.zarr,1024,1024,39,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001238.zarr,1024,1024,27,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001239.zarr,1024,1024,36,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr,271,275,236,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001241.zarr,278,263,236,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001242.zarr,481,275,237,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001243.zarr,212,218,237,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001244.zarr,325,281,239,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001245.zarr,220,226,257,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001246.zarr,281,284,257,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001247.zarr,253,210,257,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001248.zarr,234,269,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001249.zarr,246,241,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001250.zarr,246,241,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001251.zarr,170,163,140,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001252.zarr,170,163,297,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001253.zarr,803,1024,297,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001254.zarr,393,354,51,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001255.zarr,551,416,32,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001256.zarr,350,372,61,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001257.zarr,3763,2860,145,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001258.zarr,1282,838,36,3,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9822151.zarr,79360,167424,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,https://doi.org/10.5281/zenodo.5546093,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9822152.zarr,144384,93184,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836831.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836832.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836833.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836834.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836835.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836836.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836837.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836838.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836839.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836840.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836841.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836842.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836843.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836844.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836845.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836846.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836950.zarr,1636,816,156,1,1,XYZCT,,,,CC BY 4.0,idr0079,,2020-11-04,
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/1751.zarr,672,510,10,2,1,XYZCT,69,1,,CC BY-NC-SA 3.0,idr0004,https://doi.org/10.5281/zenodo.5741293,2020-12-01,692166
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/2551.zarr,1376,1040,16,2,1,XYZCT,96,6,,CC BY 4.0,idr0001,https://zenodo.org/record/5735098,2020-12-01,1230059
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/422.zarr,1344,1024,1,2,329,XYZCT,96,1,,CC BY 4.0,idr0002,,2020-12-01,179693
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/5966.zarr,1080,1080,1,5,1,XYZCT,384,9,,CC BY 4.0,idr0033,https://zenodo.org/record/5742744,2020-12-01,3231627
+0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/7825.zarr,1080,1080,1,1,1,XYZCT,96,9,,CC0 1.0,idr0094,https://zenodo.org/record/5745520,2020-12-01,10568780
+0.2,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001240.zarr,271,275,236,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2021-03-09,
+0.2,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001247.zarr,253,210,257,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-12-01,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr,1920,1920,,4,,XYC,,,,CC BY 4.0,idr0077,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0079A/9836998.zarr,1584,788,142,2,,XYZC ,,,labels (0),CC BY 4.0,idr0079,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0052A/5514375.zarr,256,256,31,3,40,XYZCT,,,"labels (cells, chromosomes)",CC BY 4.0,idr0052,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511419.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511420.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511421.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511422.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511423.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511424.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0094A/7751.zarr,1080,1080,,,,XY,96,9,labels,CC0 1.0,idr0094,,2021-12-16,10503791
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0109A/12922361.zarr,2560,2160,,,721,XYT,,,,CC BY 4.0,idr0109,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0075A/9528933.zarr,512,512,91,,,XYZ,,,,CC BY 4.0,idr0075,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0051A/4007817.zarr,333,333,201,,79,XYZT,,,,CC BY 4.0,idr0051,,2021-12-16,
+0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0040A/3491626.zarr,2048,2048,,5,20,XYCT,,,,CC BY 4.0,idr0040,,2021-12-16,
+0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr/,21115,16433,1,3,1,XYZCT,,,,CC BY 4.0,idr0073,,2022-05-05,
+0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0072B/9512.zarr,1345,1017,1,2,1,XYC,72,20,,CC BY 4.0,idr0072,,2022-05-10,12867352
+0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0083A/9822152.zarr,144384,93184,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,,2022-05-11,
+0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001247.zarr,253,210,257,2,,XYZC,,,labels (0),CC BY 4.0,idr0062,,2022-05-11,
+0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0044A/4007801.zarr,2169,2048,988,2,532,XYZCT,,,,CC BY 4.0,idr0044,,2022-05-17,

--- a/index.md
+++ b/index.md
@@ -31,6 +31,7 @@ title: "Catalog of IDR images formatted as OME-NGFF"
             <th>SizeT</th>
             <th>Axes</th>
             <th>Wells</th>
+            <th>Fields</th>
             <th>Keywords</th>
             <th>License</th>
             <th>Study</th>
@@ -51,7 +52,12 @@ title: "Catalog of IDR images formatted as OME-NGFF"
                     <img
                         alt="IDR thumbnail for image:{{image_id}}"
                         style="margin:0"
-                        src="https://idr.openmicroscopy.org/webclient/render_thumbnail/{{image_id}}/"/>
+                        {% if rec["Thumb ID"] %}
+                        src="https://idr.openmicroscopy.org/webclient/render_thumbnail/{{ rec["Thumb ID"] }}/"
+                        {% else %}
+                        src="https://idr.openmicroscopy.org/webclient/render_thumbnail/{{image_id}}/"
+                        {% endif %}
+                    />
                 </a>
             </td>
             <td>
@@ -77,6 +83,7 @@ title: "Catalog of IDR images formatted as OME-NGFF"
             <td>{{ rec.["SizeT"] }}</td>
             <td>{{ rec.["Axes"] }}</td>
             <td>{{ rec.["Wells"] }}</td>
+            <td>{{ rec.["Fields"] }}</td>
             <td>{{ rec.["Keywords"] }}</td>
             <td>{{ rec.["License"] }}</td>
             <td>

--- a/index.md
+++ b/index.md
@@ -56,7 +56,9 @@ title: "Catalog of IDR images formatted as OME-NGFF"
         <tr>
             <td>{{ rec["OME-NGFF version"] }}</td>
             <td>
-                <a target="_blank" href="http://hms-dbmi.github.io/vizarr/?source={{ rec[s3key] }}">
+                <a target="_blank"
+                    title="Open NGFF {% if rec['Wells'] %}Plate{% else %}Image{% endif %} in Vizarr"
+                    href="http://hms-dbmi.github.io/vizarr/?source={{ rec[s3key] }}">
                     <img
                         alt="IDR thumbnail for Image:{{ rec["Representative Image ID"] }}"
                         style="margin:0"

--- a/index.md
+++ b/index.md
@@ -23,7 +23,6 @@ title: "Catalog of IDR images formatted as OME-NGFF"
             <th>OME-NGFF version</th>
             <th>Thumbnail</th>
             <th>EMBL-EBI S3 key</th>
-            <th>View in IDR</th>
             <th>SizeX</th>
             <th>SizeY</th>
             <th>SizeZ</th>
@@ -35,6 +34,7 @@ title: "Catalog of IDR images formatted as OME-NGFF"
             <th>Keywords</th>
             <th>License</th>
             <th>Study</th>
+            <th>View in IDR</th>
             <th>DOI</th>
             <th>Date added</th>
         </tr>
@@ -65,17 +65,6 @@ title: "Catalog of IDR images formatted as OME-NGFF"
                     {{ image_name }}
                 </a>
             </td>
-            <td>
-                {% if rec["Wells"] %}
-                    <a target="_blank" href="https://idr.openmicroscopy.org/webclient/?show=plate-{{ image_id }}">
-                        Plate in IDR
-                    </a>
-                {% else %}
-                    <a target="_blank" href="https://idr.openmicroscopy.org/webclient/img_detail/{{ image_id }}/">
-                        Image in IDR
-                    </a>
-                {% endif %}
-            </td>
             <td>{{ rec.["SizeX"] }}</td>
             <td>{{ rec.["SizeY"] }}</td>
             <td>{{ rec.["SizeZ"] }}</td>
@@ -90,6 +79,17 @@ title: "Catalog of IDR images formatted as OME-NGFF"
                 <a href="https://idr.openmicroscopy.org/search/?query=Name:{{ rec[studykey] }}">
                     {{ rec.["Study"] }}
                 </a>
+            </td>
+            <td>
+                {% if rec["Wells"] %}
+                    <a target="_blank" href="https://idr.openmicroscopy.org/webclient/?show=plate-{{ image_id }}">
+                        Plate in IDR
+                    </a>
+                {% else %}
+                    <a target="_blank" href="https://idr.openmicroscopy.org/webclient/img_detail/{{ image_id }}/">
+                        Image in IDR
+                    </a>
+                {% endif %}
             </td>
             <td>{{ rec.["DOI"] }}</td>
             <td>{{ rec.["Date added"] }}</td>

--- a/index.md
+++ b/index.md
@@ -50,13 +50,9 @@ title: "Catalog of IDR images formatted as OME-NGFF"
             <td>
                 <a target="_blank" href="http://hms-dbmi.github.io/vizarr/?source={{ rec[s3key] }}">
                     <img
-                        alt="IDR thumbnail for image:{{image_id}}"
+                        alt="IDR thumbnail for Image:{{ rec["Representative Image ID"] }}"
                         style="margin:0"
-                        {% if rec["Thumb ID"] %}
-                        src="https://idr.openmicroscopy.org/webclient/render_thumbnail/{{ rec["Thumb ID"] }}/"
-                        {% else %}
-                        src="https://idr.openmicroscopy.org/webclient/render_thumbnail/{{image_id}}/"
-                        {% endif %}
+                        src="https://idr.openmicroscopy.org/webclient/render_thumbnail/{{ rec["Representative Image ID"] }}/"
                     />
                 </a>
             </td>

--- a/index.md
+++ b/index.md
@@ -16,13 +16,14 @@ title: "Catalog of IDR images formatted as OME-NGFF"
 }
 </script>
 
-<table class="display" id="table">
+<table class="display table" id="table">
     <thead>
 <!-- TODO: should be read from data file -->
         <tr>
             <th>OME-NGFF version</th>
             <th>Thumbnail</th>
             <th>EMBL-EBI S3 key</th>
+            <th>View in IDR</th>
             <th>SizeX</th>
             <th>SizeY</th>
             <th>SizeZ</th>
@@ -57,6 +58,17 @@ title: "Catalog of IDR images formatted as OME-NGFF"
                 <a href="{{ rec[s3key] }}">
                     {{ image_name }}
                 </a>
+            </td>
+            <td>
+                {% if rec["Wells"] %}
+                    <a target="_blank" href="https://idr.openmicroscopy.org/webclient/?show=plate-{{ image_id }}">
+                        Plate in IDR
+                    </a>
+                {% else %}
+                    <a target="_blank" href="https://idr.openmicroscopy.org/webclient/img_detail/{{ image_id }}/">
+                        Image in IDR
+                    </a>
+                {% endif %}
             </td>
             <td>{{ rec.["SizeX"] }}</td>
             <td>{{ rec.["SizeY"] }}</td>

--- a/index.md
+++ b/index.md
@@ -16,6 +16,14 @@ title: "Catalog of IDR images formatted as OME-NGFF"
 }
 </script>
 
+<style>
+    .page-content .wrapper {
+        box-sizing: border-box;
+        width: 100%;
+        max-width: 100%;
+    }
+</style>
+
 <table class="display table" id="table">
     <thead>
 <!-- TODO: should be read from data file -->

--- a/index.md
+++ b/index.md
@@ -48,7 +48,7 @@ title: "Catalog of IDR images formatted as OME-NGFF"
         <tr>
             <td>{{ rec["OME-NGFF version"] }}</td>
             <td>
-                <a href="http://hms-dbmi.github.io/vizarr/?source={{ rec[s3key] }}">
+                <a target="_blank" href="http://hms-dbmi.github.io/vizarr/?source={{ rec[s3key] }}">
                     <img
                         alt="IDR thumbnail for image:{{image_id}}"
                         style="margin:0"

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ title: "Catalog of IDR images formatted as OME-NGFF"
 <!-- TODO: should be read from data file -->
         <tr>
             <th>OME-NGFF version</th>
-            <th>Thumbnail</th>
+            <th>Thumbnail (open in <a target="_blank" href="https://github.com/hms-dbmi/vizarr">Vizarr</a>)</th>
             <th>EMBL-EBI S3 key</th>
             <th>SizeX</th>
             <th>SizeY</th>


### PR DESCRIPTION
Testing: deployed at https://will-moore.github.io/ome-ngff-samples/

Sometimes it's useful to see how IDR shows an Image in iviewer.
Or to see how a plate is shown in IDR. This adds a "Plate/Image in IDR" column (which also allows you to search the list for "Plate" instead of relying on the Wells column to know what's a plate.

Also, for Plates I added a `Representative Image ID` column to the table, so we can show a valid thumbnail for Images and Plates (currently get thumb placeholder for most plates).

Also added a "Fields" column for plates as in recent discussions it's been useful to find sample data with lots of Fields per Well. 

Also, the `vizarr` link opens in a new browser Tab. I don't know if others prefer this behaviour but it feels right to me. I keep closing the vizarr viewer and then realise I've lost the samples page! 

Added "Open in Vizarr" to the Thumbnails column (otherwise it's not clear that these are links).

I made the table take up the full page width as this is much easier to read.