### PR TITLE
bioformats2raw.layout sample

### DIFF
--- a/_data/table.csv
+++ b/_data/table.csv
@@ -73,8 +73,8 @@ OME-NGFF version,EMBL-EBI bucket (current),SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,We
 0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0083A/9822152.zarr,144384,93184,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,,2022-05-11,9822152
 0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001247.zarr,253,210,257,2,,XYZC,,,labels (0),CC BY 4.0,idr0062,,2022-05-11,6001247
 0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0044A/4007801.zarr,2169,2048,988,2,532,XYZCT,,,,CC BY 4.0,idr0044,,2022-05-17,4007801
-0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0056B/7361.zarr,659,493,1,4,1,XYZCT,384,30,,CC BY 4.0,idr0056,,2022-06-06,9621401
-0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0128E/9701.zarr,2048,2048,1,2,1,XYZCT,384,1,,CC BY 4.0,idr0128,,2022-06-01,13966432
+0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0056B/7361.zarr,659,493,1,4,1,XYZCT,384,30,bioformats2raw.layout,CC BY 4.0,idr0056,,2022-06-06,9621401
+0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0128E/9701.zarr,2048,2048,1,2,1,XYZCT,384,1,bioformats2raw.layout,CC BY 4.0,idr0128,,2022-06-01,13966432
 0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0013A/3451.zarr,1344,1024,,,93,XYT,384,1,,CC0 1.0,idr0013,,2022-06-03,1483351
 0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0054A/5025551.zarr,2702,2700,1,27,1,XYZCT,,,,CC BY 4.0,idr0054,,2022-06-03,5025551
 0.4,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0054A/5025552.zarr,2701,2701,1,27,1,XYZCT,,,,CC BY 4.0,idr0054,,2022-06-03,5025552

--- a/_data/table.csv
+++ b/_data/table.csv
@@ -53,6 +53,7 @@ OME-NGFF version,EMBL-EBI bucket (current),SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,We
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/7825.zarr,1080,1080,1,1,1,XYZCT,96,9,,CC0 1.0,idr0094,https://zenodo.org/record/5745520,2020-12-01,10568780
 0.2,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001240.zarr,271,275,236,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2021-03-09,6001240
 0.2,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001247.zarr,253,210,257,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-12-01,6001247
+0.2,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/idr0070A/9838562.zarr,,,,,,,,,bioformats2raw.layout,CC BY 4.0,idr0070,,2022-10-14,9838562
 0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr,1920,1920,,4,,XYC,,,,CC BY 4.0,idr0077,,2021-12-16,9836842
 0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0079A/9836998.zarr,1584,788,142,2,,XYZC ,,,labels (0),CC BY 4.0,idr0079,,2021-12-16,9836998
 0.3,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0052A/5514375.zarr,256,256,31,3,40,XYZCT,,,"labels (cells, chromosomes)",CC BY 4.0,idr0052,,2021-12-16,5514375

--- a/index.md
+++ b/index.md
@@ -93,11 +93,12 @@ title: "Catalog of IDR images formatted as OME-NGFF"
                 <button class="no_border" title="Copy S3 URL to clipboard" onclick="copyTextToClipboard('{{ rec[s3key] }}')">
                     <img class="icon" src="assets/img/copy.png"/>
                 </button>
-                {% unless rec['Keywords'] == "bioformats2raw.layout" %}
+                <!-- vizarr supports Plate or Non-bioformats2raw images -->
+                {% if rec['Wells'] or rec['Keywords'] != "bioformats2raw.layout" %}
                 <a title="View NGFF {% if rec['Wells'] %}Plate{% else %}Image{% endif %} in Vizarr" target="_blank"
                     href="http://hms-dbmi.github.io/vizarr/?source={{ rec[s3key] }}">
                     <img class="icon vizarr" src="assets/img/vizarr_logo.png"/></a>
-                {% endunless %}
+                {% endif %}
                 <a title="Validate NGFF with 'ome-ngff-validator' in new browser tab" target="_blank"
                     href="https://ome.github.io/ome-ngff-validator/?source={{ rec[s3key] }}">
                     <img class="icon" style="opacity: 0.5" src="assets/img/check.png"/></a>

--- a/index.md
+++ b/index.md
@@ -93,9 +93,11 @@ title: "Catalog of IDR images formatted as OME-NGFF"
                 <button class="no_border" title="Copy S3 URL to clipboard" onclick="copyTextToClipboard('{{ rec[s3key] }}')">
                     <img class="icon" src="assets/img/copy.png"/>
                 </button>
+                {% unless rec['Keywords'] == "bioformats2raw.layout" %}
                 <a title="View NGFF {% if rec['Wells'] %}Plate{% else %}Image{% endif %} in Vizarr" target="_blank"
                     href="http://hms-dbmi.github.io/vizarr/?source={{ rec[s3key] }}">
                     <img class="icon vizarr" src="assets/img/vizarr_logo.png"/></a>
+                {% endunless %}
                 <a title="Validate NGFF with 'ome-ngff-validator' in new browser tab" target="_blank"
                     href="https://ome.github.io/ome-ngff-validator/?source={{ rec[s3key] }}">
                     <img class="icon" style="opacity: 0.5" src="assets/img/check.png"/></a>


### PR DESCRIPTION
We currently have no bioformats2raw examples in this list. Prompted by https://forum.image.sc/t/intermission-ome-ngff-0-4-1-bioformats2raw-0-5-0-et-al/72214 I've started to add 1 with this PR...

This is v0.2 (which is currently the output from bioformats2raw).
Since bioformats2raw.layout isn't supported by vizarr, I don't show the vizarr link if the Keywords column is `bioformats2raw.layout`

Can be viewed in ome-ngff-validator:
https://ome.github.io/ome-ngff-validator/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/idr0070A/9838562.zarr