### PR TITLE
Add missing comma in schema.org description

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ title: "Catalog of IDR images formatted as OME-NGFF"
   "@context": "http://schema.org",
   "@type": "Catalog",
   "inLanguage": "en-US",
-  "name": "IDR OME-NGFF Samples"
+  "name": "IDR OME-NGFF Samples",
   "publisher": {
     "@type": "Organization",
     "name": "GitHub"


### PR DESCRIPTION
Discovered by visiting https://validator.schema.org/#url=https%3A%2F%2Fidr.github.io%2Fome-ngff-samples%2F as a part of https://www.denbi.de/de-nbi-events/2-uncategorised/1483-bio-schemas4nfdi-lightweight-domain-metadata-not-only-for-nfdi-consortia

