### PR TITLE
Update to 'DataCatalog'

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: "Catalog of IDR images formatted as OME-NGFF"
 <script type="application/ld+json">
 {
   "@context": "http://schema.org",
-  "@type": "Catalog",
+  "@type": "DataCatalog",
   "inLanguage": "en-US",
   "name": "IDR OME-NGFF Samples",
   "publisher": {
@@ -12,7 +12,11 @@ title: "Catalog of IDR images formatted as OME-NGFF"
     "name": "GitHub"
   },
   "copyrightYear": "2022",
-  "discussionUrl": "https://github.com/IDR/ome-ngff-samples/issues"
+  "discussionUrl": "https://github.com/IDR/ome-ngff-samples/issues",
+
+  "accessMode": "visual",
+  "measurementTechnique": "microscopy"
+
 }
 </script>
 


### PR DESCRIPTION
After #17, validation ran further and complained that "Catalog" is not a schema.org in type. This PR updates the metadata to use https://schema.org/DataCatalog and adds a few other properties that may be of interest.