### PR TITLE
rename table.csv column to 'File Path'

### DIFF
--- a/_data/table.csv
+++ b/_data/table.csv
@@ -1,4 +1,4 @@
-OME-NGFF version,EMBL-EBI bucket (current),SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,Wells,Fields,Keywords,License,Study,DOI,Date added,Representative Image ID
+OME-NGFF version,File Path,SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,Wells,Fields,Keywords,License,Study,DOI,Date added,Representative Image ID
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/12689244.zarr,4992,4255,401,3,1,XYZCT,,,,CC BY 4.0,idr0106,,2020-11-04,12689244
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/179706.zarr,1344,1024,1,2,329,XYZCT,,,,CC BY 4.0,idr0002,,2020-11-04,179706
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/1884807.zarr,256,256,1,3,1,XYZCT,,,,CC BY 4.0,idr0021,,2020-11-04,1884807


### PR DESCRIPTION
Testing https://biofile-finder.allencell.org/ with the tables.csv from here, just needs one column renamed...

Loading the tables.csv from this PR, grouping by Zarr version and Axes, I get https://biofile-finder.allencell.org/app?group=OME-NGFF+version&group=Axes&openFolder=%5B%220.4%22%5D&openFolder=%5B%220.4%22%2C%22XYZC%22%5D&openFolder=%5B%220.4%22%2C%22XYZCT%22%5D&source=%7B%22name%22%3A%22table.csv+%2830%2F10%2F2024+10%3A05%3A31%29%22%2C%22type%22%3A%22csv%22%2C%22uri%22%3A%22https%3A%2F%2Fraw.githubusercontent.com%2FIDR%2Fome-ngff-samples%2Fb1156dad688b730038347df902e3a3a56403bec5%2F_data%2Ftable.csv%22%7D

(NB: Thumbnails not created for Plates, but they are created on the fly for other v0.4 Zarrs!)

![Screenshot 2024-10-30 at 10 06 47](https://github.com/user-attachments/assets/3c8f3abd-a89b-4776-aa13-312362d6bd44)

