### PR TITLE
Add example aws s3 sync command

### DIFF
--- a/index.md
+++ b/index.md
@@ -49,6 +49,13 @@ title: "Catalog of IDR images formatted as OME-NGFF"
     @keyframes seesaw { from { transform: rotate(-0.05turn) } to { transform: rotate(0.05turn); }  }
 </style>
 
+<p>To download samples, you can use <code>aws</code> CLI. E.g</p>
+
+<code>
+$ aws s3 sync --endpoint-url https://uk1s3.embassy.ebi.ac.uk --no-sign-request s3://idr/zarr/v0.4/idr0062A/6001240.zarr/ 6001240.zarr
+</code>
+
+
 <table class="display table" id="table">
     <thead>
 <!-- TODO: should be read from data file -->


### PR DESCRIPTION
Since I never know how to find this out and it takes a while to look it up, adding `aws sync` command to this page:

See https://forum.image.sc/t/separate-tiles-to-ome-zarr/109071/30

Testing:

This branch is deployed at https://will-moore.github.io/ome-ngff-samples/