### PR TITLE
Rename URL column to File Path

### DIFF
--- a/_data/table.csv
+++ b/_data/table.csv
@@ -1,4 +1,4 @@
-OME-NGFF version,EMBL-EBI bucket (current),SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,Wells,Fields,Keywords,License,Study,DOI,Date added,Representative Image ID
+OME-NGFF version,File Path,SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,Wells,Fields,Keywords,License,Study,DOI,Date added,Representative Image ID
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/12689244.zarr,4992,4255,401,3,1,XYZCT,,,,CC BY 4.0,idr0106,,2020-11-04,12689244
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/179706.zarr,1344,1024,1,2,329,XYZCT,,,,CC BY 4.0,idr0002,,2020-11-04,179706
 0.1,https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/1884807.zarr,256,256,1,3,1,XYZCT,,,,CC BY 4.0,idr0021,,2020-11-04,1884807

--- a/index.md
+++ b/index.md
@@ -79,7 +79,7 @@ $ aws s3 sync --endpoint-url https://uk1s3.embassy.ebi.ac.uk --no-sign-request s
         </tr>
     </thead>
     <tbody>
-{% assign s3key = "EMBL-EBI bucket (current)" %}
+{% assign s3key = "File Path" %}
 {% assign studykey = "Study" %}
 {% for rec in site.data.table %}
 {% capture image_name %}{{ rec.[s3key] | split: "/" | last }}{% endcapture %}


### PR DESCRIPTION
The renaming of this column allows the csv to be consumed by BioFile Finder.

CSV at https://raw.githubusercontent.com/will-moore/ome-ngff-samples/9e56eecee22a0a8a230c5b408bb5d4dc30591476/_data/table.csv 

In BFF at https://bff.allencell.org/app?c=OME-NGFF+version%3A0.25%2CFile+Path%3A0.25%2CSizeX%3A0.25%2CSizeY%3A0.25&v=2&source=%7B%22name%22%3A%22table.csv+%2803%2F10%2F2025+14%3A23%3A19%29%22%2C%22type%22%3A%22csv%22%2C%22uri%22%3A%22https%3A%2F%2Fraw.githubusercontent.com%2Fwill-moore%2Fome-ngff-samples%2F9e56eecee22a0a8a230c5b408bb5d4dc30591476%2F_data%2Ftable.csv%22%7D